### PR TITLE
Remove JSX from JS preprocessors

### DIFF
--- a/src/stacks.js
+++ b/src/stacks.js
@@ -49,11 +49,6 @@ export const JS_PREPROCESSORS = [
     website: 'http://coffeescript.org/'
   },
   {
-    name: 'JSX',
-    icon: 'jsx.svg',
-    website: 'https://reactjs.org/docs/glossary.html#jsx'
-  },
-  {
     name: 'ClojureScript',
     icon: 'cljs.svg',
     website: 'https://clojurescript.org/'


### PR DESCRIPTION
In my opinion JSX shoud not be listed as a JS preprocessor as it can only be used with React (which is already listed in JS Frameworks.